### PR TITLE
Fix macro recording

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -422,7 +422,6 @@ class CMAdapter {
     }
 
     this.dispatch('change', this, change);
-    this.dispatch('cursorActivity', this, e);
   };
 
   setOption(key, value) {

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export function initVimMode(editor, statusbarNode = null, StatusBarClass = Statu
   });
 
   VimMode.defineExtension('openDialog', function(html, callback, options) {
-    statusbar.setSec(html, callback, options);
+    return statusbar.setSec(html, callback, options);
   });
 
   VimMode.defineExtension('openNotification', function(html) {

--- a/src/statusbar.js
+++ b/src/statusbar.js
@@ -57,6 +57,8 @@ export default class VimStatusBar {
 
       this.addInputListeners();
     }
+
+    return this.closeInput;
   }
 
   setText(text) {


### PR DESCRIPTION
First thing I fixed was I started returning `closeInput` for `openDialogue` as expected https://github.com/codemirror/CodeMirror/blob/f9c0e370ec4ddace08bb799965b3f46f9536a553/addon/dialog/dialog.js#L96

Then I fixed a issue where `cursorActivity` was dispatched twice on `change` events, once during the change and once from monaco's cursor activity. This caused `maybeReset` to be true because it goes through https://github.com/brijeshb42/monaco-vim/blob/master/src/cm/keymap_vim.js#L5234-L5239 twice