### PR TITLE
fix: correct editor variable assignment

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -1057,7 +1057,8 @@ class CMAdapter {
   }
 
   indentLine(line, indentRight = true) {
-    const cursors = this.editor._getCursors();
+    const { editor } = this
+    const cursors = editor._getCursors();
     const pos = new Position(line + 1, 1);
     const sel = Selection.fromPositions(pos, pos);
     // no other way than to use internal apis to preserve the undoStack for a batch of indents


### PR DESCRIPTION
https://github.com/brijeshb42/monaco-vim/blob/master/src/cm_adapter.js#L1064  editor in this line did't  reference to  `this.editor`， so `indentLine` operation will fire an error, this PR fix it 
