### PR TITLE
Update cm_adapter.js

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -383,18 +383,6 @@ class CMAdapter {
   }
 
   handleCursorChange = (e) => {
-    const { position, source } = e;
-    const { editor } = this;
-
-    if (!this.ctxInsert.get() && e.source === 'mouse') {
-      const maxCol = editor.getModel().getLineMaxColumn(position.lineNumber);
-
-      if (e.position.column === maxCol) {
-        editor.setPosition(new Position(e.position.lineNumber, maxCol - 1));
-        return;
-      }
-    }
-
     this.dispatch('cursorActivity', this, e);
   }
 


### PR DESCRIPTION
Mouse selection currently has a glitch when trying to select multiple lines or going past the end of a line. 

The glitch is not present when the handling is removed, and I've verified that all edge handling in general seems to still work.