### PR TITLE
Always handle the esc-key

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -313,7 +313,7 @@ class CMAdapter {
   handleKeyDown = (e) => {
     // Allow previously registered keydown listeners to handle the event and
     // prevent this extension from also handling it.
-    if (e.browserEvent.defaultPrevented) {
+    if (e.browserEvent.defaultPrevented & e.keyCode !== KeyCode.Escape) {
       return;
     }
 


### PR DESCRIPTION
Workaround for #27.

Prevents monaco-vim from ignoring ESC, because monaco always uses `preventDefault` on esc-keycode-events, resulting in being unable to exit Insert/Visual-mode.

A real fix should be able to differentiate between monaco-ignored and user-ignored events, but I am unsure how to solve this. This fix can be used in the meantime for the vast majority of use-cases. Without it the library is completely broken in my honest opinion.