### PR TITLE
Correctly clean statusbar on dispose

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export function initVimMode(editor, statusbarNode = null, StatusBarClass = Statu
   vimAdapter.on('dispose', function() {
     statusBar.toggleVisibility(false);
     statusBar.closeInput();
-    statusBar.innerHTML = '';
+    statusbarNode.innerHTML = '';
   });
 
   statusBar.toggleVisibility(true);


### PR DESCRIPTION
`dispose` does not correctly clean the status bar on exit for me because it is using the wrong variable.

If vimMode is initialized/disposed multiple times the status bar fills with multiple mode-specifiers.

This fixes the issue.