### PR TITLE
Fix infinite recursion for replacements.

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -901,8 +901,20 @@ class CMAdapter {
     const matches = model.findMatches(query, false, isRegex, matchCase) || [];
 
     return {
+      getMatches() {return matches;},
       findNext() {return this.find(false);},
       findPrevious() {return this.find(true);},
+      jumpTo(index) {
+        if (!matches || !matches.length) {
+          return false;
+        }
+        var match = matches[index];
+        lastSearch = match.range;
+        context.highlightRanges([lastSearch], 'currentFindMatch');
+        context.highlightRanges(matches.map(m => m.range).filter(r => !r.equalsRange(lastSearch)));
+
+        return lastSearch;
+      },
       find(back) {
         if (!matches || !matches.length) {
           return false;


### PR DESCRIPTION
tl;dr: only use explicit loops with regards to the number of matches.
Previous implementation did while(true) loops and broke out when it ran
out of matches. The break condition never triggered because of the match
regex always finding the first line.

Instead, explicitly remove and replace each specific match.