### PR TITLE
Bugfix toggleOverwrite

### DIFF
--- a/src/cm/keymap_vim.js
+++ b/src/cm/keymap_vim.js
@@ -2251,7 +2251,7 @@ var Vim = function() {
       }
     },
     toggleOverwrite: function(cm) {
-      if (!cm.state.overwrite) {
+      if (!cm.replaceMode) {
         cm.toggleOverwrite(true);
         cm.setOption('keyMap', 'vim-replace');
         CodeMirror.signal(cm, "vim-mode-change", {mode: "replace"});


### PR DESCRIPTION
cm.state.overwrite is always undefined, so it wouldn't actually toggle
