### PR TITLE
Clear the StatusBar's node rather than the StatusBar element itself

### DIFF
--- a/src/statusbar.js
+++ b/src/statusbar.js
@@ -91,7 +91,7 @@ export default class VimStatusBar {
   };
 
   clear = () => {
-    this.setInnerHtml_(this, '');
+    this.setInnerHtml_(this.node, '');
   }
 
   inputKeyUp = (e) => {


### PR DESCRIPTION
Clear the StatusBar's node rather than the StatusBar element itself (the first arg to setInnerHtml_ should be a Node).

This was resulting in an error when clear() was called:

Uncaught TypeError: Cannot read property 'length' of undefined
TypeError: Cannot read property 'length' of undefined
