### PR TITLE
fix: decrease bundle size when use monaco-vim

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"No test in this repo\"",
     "start": "webpack-dev-server --mode development --host=0.0.0.0 --port=8080",
     "clean": "rm -rf lib dist local",
-    "dist": "webpack --mode production",
+    "dist": "rm -rf ./dist && webpack --mode production",
     "babel": "NODE_ENV=production babel ./src -d lib --ignore 'demo.js'",
     "build": "npm run clean && npm run babel && npm run dist",
     "local": "mkdir -p local && cp -r lib dist package.json local",

--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -9,7 +9,7 @@ import {
   Selection,
   SelectionDirection,
   editor as monacoEditor,
-} from 'monaco-editor';
+} from 'monaco-editor/esm/vs/editor/editor.api';
 import { TypeOperations } from 'monaco-editor/esm/vs/editor/common/controller/cursorTypeOperations';
 const VerticalRevealType = {
   Bottom: 4,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,11 +65,11 @@ module.exports = (_env, argv) => {
       new MonacoWebpackPlugin(),
     ],
     externals: isProd ? {
-      'monaco-editor': {
+      'monaco-editor/esm/vs/editor/editor.api': {
         root: 'monaco',
-        commonjs: 'monaco-editor',
-        commonjs2: 'monaco-editor',
-        amd: 'vs/editor/editor.main',
+        commonjs: 'monaco-editor/esm/vs/editor/editor.api',
+        commonjs2: 'monaco-editor/esm/vs/editor/editor.api',
+        amd: 'vs/editor/editor.api',
       },
       'monaco-editor/esm/vs/editor/common/controller/cursorTypeOperations': {
         commonjs: 'monaco-editor/esm/vs/editor/common/controller/cursorTypeOperations',


### PR DESCRIPTION
`import { xxx } from 'monaco-editor'` will end up importing all the editor languages and features.