### PR TITLE
Only import the editor API instead of the whole package so that Webpack only loads relevant code

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -9,7 +9,7 @@ import {
   Selection,
   SelectionDirection,
   editor as monacoEditor,
-} from 'monaco-editor';
+} from 'monaco-editor/esm/vs/editor/editor.api';
 import { TypeOperations } from 'monaco-editor/esm/vs/editor/common/controller/cursorTypeOperations';
 const VerticalRevealType = {
   Bottom: 4,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,10 +68,10 @@ module.exports = (_env, argv) => {
       new MonacoWebpackPlugin(),
     ],
     externals: isProd ? {
-      'monaco-editor': {
+      'monaco-editor/esm/vs/editor/editor.api': {
         root: 'monaco',
-        commonjs: 'monaco-editor',
-        commonjs2: 'monaco-editor',
+        commonjs: 'monaco-editor/esm/vs/editor/editor.api',
+        commonjs2: 'monaco-editor/esm/vs/editor/editor.api',
         amd: 'vs/editor/editor.main',
       },
       'monaco-editor/esm/vs/editor/common/controller/cursorTypeOperations': {


### PR DESCRIPTION
When you import directly from `monaco-editor` webpack will pull in the entire monaco package, including all supported languages.
It is recommended to import from `monaco-editor/esm/vs/editor/editor.api` instead.

See: https://github.com/microsoft/monaco-editor-webpack-plugin/issues/43 for more information