### PR TITLE
Fixed AltGr issue

### DIFF
--- a/src/cm/keymap_vim.js
+++ b/src/cm/keymap_vim.js
@@ -343,6 +343,10 @@ var Vim = function() {
       // Keypress character binding of format "'a'"
       return key.charAt(1);
     }
+    if (key == 'AltGraph') {
+      //Handle AltGr character
+      return false;
+    }
     var pieces = key.split(/-(?!$)/);
     var lastPiece = pieces[pieces.length - 1];
     if (pieces.length == 1 && pieces[0].length == 1) {


### PR DESCRIPTION
There was an issue, where AltGr was treated as a regular character in "cmKeyToVimKey". Added in a check to solve this, as this made for example f{ impossible on my keyboard.