### PR TITLE
Do not use monaco global object, fix for monaco 0.22

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -158,7 +158,7 @@ class Marker {
 
 function monacoToCmKey(e, skip = false) {
   let addQuotes = true;
-  let keyName = monaco.KeyCode[e.keyCode];
+  let keyName = KeyCode[e.keyCode];
 
   if (e.key) {
     keyName = e.key;


### PR DESCRIPTION
In its last version, monaco-editor doesn't export a global `monaco` object anymore