### PR TITLE
Fixes to substitute

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -964,7 +964,7 @@ class CMAdapter {
             return false;
           }
         } else {
-          const pos = lastSearch ? lastSearch.getEndPosition() : monacoPos;
+          const pos = lastSearch ? model.getPositionAt(model.getOffsetAt(lastSearch.getStartPosition()) + 1) : monacoPos;
           match = model.findNextMatch(query, pos, isRegex, matchCase);
           if (!match || !pos.isBeforeOrEqual(match.range.getStartPosition())) {
             return false;


### PR DESCRIPTION
Fixes #60 

Removed special-case code for `replaceAllNext()` so there's only one implementation of the search logic.  (Note this logic is now very similar to that in upstream codemirror)

Fixed another bug where if you had many matches to replace very close together, every other one would be missed.
For example starting with:
```
import import import import import
```
and executing `:s/import/foo/g` would leave you with:
```
foo import foo import foo
```

Also adds an undo checkpoint before substitution which was previously missing, so now undo behaves as expected.