### PR TITLE
Accept by default all versions of monaco editor starting from 0.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "webpack-dev-server": "^4.7.4"
   },
   "peerDependencies": {
-    "monaco-editor": "^0.32.0"
+    "monaco-editor": ">=0.32.0"
   }
 }


### PR DESCRIPTION
^0.32.0 is only accepting patches, so this package can't be used with monaco 0.33