### PR TITLE
fix ctrl-[key] bindings

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -209,7 +209,7 @@ function monacoToCmKey(e, skip = false) {
       break;
   }
 
-  if (keyName.startsWith("KEY_")) {
+  if (keyName.startsWith("Key")) {
     key = keyName[keyName.length - 1].toLowerCase();
   } else if (keyName.endsWith("Arrow")) {
     skipOnlyShiftCheck = true;


### PR DESCRIPTION
Fix to https://github.com/brijeshb42/monaco-vim/issues/94

Keyboardevent.code prefix is "Key" not "KEY_" which was causing an ctrl-[key] keyboard events to not be parsed properly later on to CodeMirror.