### PR TITLE
Fix smart indent typo

### DIFF
--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -1257,7 +1257,7 @@ class CMAdapter {
   }
 
   smartIndent() {
-    this.editor.getAction("editor.action.formatSelection").run();
+    this.editor.getAction("editor.action.reindentselectedlines").run();
   }
 
   moveCursorTo(to) {

--- a/src/cm_adapter.js
+++ b/src/cm_adapter.js
@@ -1257,7 +1257,7 @@ class CMAdapter {
   }
 
   smartIndent() {
-    editor.getAction("editor.action.formatSelection").run();
+    this.editor.getAction("editor.action.formatSelection").run();
   }
 
   moveCursorTo(to) {


### PR DESCRIPTION
Smart-indenting is not working for me, probably because this function calls `editor` instead of `this.editor`