### PR TITLE
Fixup incorrect function call

### DIFF
--- a/src/cm/keymap_vim.js
+++ b/src/cm/keymap_vim.js
@@ -3191,7 +3191,7 @@ var Vim = function () {
         head.line--;
         cm.setSelection(anchor, head);
         text = cm.getSelection();
-        cm.replaceSelection("");
+        cm.replaceSelections("");
         finalHead = anchor;
       } else {
         text = cm.getSelection();
@@ -7103,7 +7103,8 @@ var Vim = function () {
         if (change instanceof InsertModeKey) {
           CodeMirror.lookupKey(change.keyName, "vim-insert", keyHandler);
         } else if (typeof change == "string") {
-          cm.replaceSelection(change);
+          window.cm = cm;
+          cm.replaceSelections(change);
         } else {
           var start = cm.getCursor();
           var end = offsetCursor(start, 0, change[0].length);


### PR DESCRIPTION
`CMAdapter.replaceSelection` never existed in git-history, and probably is misspelled.

Which causes (repro: insert mode, type, normal mode, hit dot `.`):
```
TypeError: cm.replaceSelection is not a function
    at repeatInsertModeChanges (keymap_vim.js:7879:14)
    at repeatInsert (keymap_vim.js:7812:9)
    at _repeatLastEdit (keymap_vim.js:7823:9)
    at Object.repeatLastEdit (keymap_vim.js:4377:7)
    at Object.processAction (keymap_vim.js:2591:30)
    at Object.processCommand (keymap_vim.js:2484:16)
    at eval (keymap_vim.js:2142:35)
    at CMAdapter.operation (cm_adapter.js:591:14)
    at eval (keymap_vim.js:2135:21)
    at handleKeyDown (cm_adapter.js:1350:11)
```

PR simply replaces them with correct function name i.e. `replaceSelections`.

This was first reported in https://github.com/compiler-explorer/compiler-explorer/issues/4119.